### PR TITLE
fix(ports): add check before trying to compute port position

### DIFF
--- a/src/reducers/flow.reducer.js
+++ b/src/reducers/flow.reducer.js
@@ -106,16 +106,21 @@ export function calculatePortsPosition(state, action) {
 		return nodes.reduce((cumulativeState, node) => {
 			const nodeType = node.getNodeType();
 			const ports = state.get('ports').filter(port => port.nodeId === node.id);
-			const calculatePortPosition = state.getIn(['nodeTypes', nodeType, 'component'])
-				.calculatePortPosition;
-			return cumulativeState.mergeIn(
-				['ports'],
-				calculatePortPosition(
-					ports,
-					node.getPosition(),
-					node.getSize(),
-				),
-			);
+			const component = state.getIn(['nodeTypes', nodeType, 'component']);
+			if (component) {
+				const calculatePortPosition = component.calculatePortPosition;
+				if (calculatePortPosition) {
+					return cumulativeState.mergeIn(
+						['ports'],
+						calculatePortPosition(
+							ports,
+							node.getPosition(),
+							node.getSize(),
+						),
+					);
+				}
+			}
+			return state;
 		}, state);
 	}
 	return state;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
calculating port position on unknown node can result it undefined error


**What is the new behavior?**
check are made to be sure that the component hold a calculatatePortPosition value


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: