### PR TITLE
fix(TFD-2034): Fixes d3Node position on drag start

### DIFF
--- a/src/components/node/AbstractNode.component.js
+++ b/src/components/node/AbstractNode.component.js
@@ -126,7 +126,6 @@ class AbstractNode extends React.Component {
 	}
 
 	onDrag() {
-		this.d3Node.data([this.props.node.getPosition()]);
 		const position = {
 			x: event.x,
 			y: event.y,
@@ -142,6 +141,7 @@ class AbstractNode extends React.Component {
 	onDragEnd() {
 		const position = this.getEventPosition(event);
 		this.props.moveNodeToEnd(this.props.node.id, position);
+		this.d3Node.data([position]);
 		if (this.props.onDragEnd) {
 			this.props.onDragEnd(position);
 		}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
On drag start the d3 event had the old position before snap.

**What is the new behavior?**
This change now sets updates the d3Node position when drags ends to
reflect the new "snapped" position.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No