### PR TITLE
feat: Sets default grid size

### DIFF
--- a/src/components/grid/__snapshots__/Grid.test.js.snap
+++ b/src/components/grid/__snapshots__/Grid.test.js.snap
@@ -14,21 +14,21 @@ exports[`Grid.component should render a grid by default 1`] = `
     </pattern>
     <pattern
       fill="none"
-      height={62.5}
+      height={40}
       id="grid"
       patternUnits="userSpaceOnUse"
       stroke="#BFBDBD"
       strokeWidth="0.5"
-      width={62.5}
+      width={40}
       x={0}
       y={0}>
       <rect
         fill="url(#smallGrid)"
         fillOpacity={1}
-        height={62.5}
-        width={62.5} />
+        height={40}
+        width={40} />
       <path
-        d="M 62.5 0 L 0 0 0 62.5" />
+        d="M 40 0 L 0 0 0 40" />
     </pattern>
   </defs>
   <rect
@@ -61,21 +61,21 @@ exports[`Grid.component should render custom component with transform injected 1
     </pattern>
     <pattern
       fill="none"
-      height={62.5}
+      height={40}
       id="grid"
       patternUnits="userSpaceOnUse"
       stroke="#BFBDBD"
       strokeWidth="0.5"
-      width={62.5}
+      width={40}
       x={0}
       y={0}>
       <rect
         fill="url(#smallGrid)"
         fillOpacity={1}
-        height={62.5}
-        width={62.5} />
+        height={40}
+        width={40} />
       <path
-        d="M 62.5 0 L 0 0 0 62.5" />
+        d="M 40 0 L 0 0 0 40" />
     </pattern>
   </defs>
   <rect

--- a/src/constants/flowdesigner.constants.js
+++ b/src/constants/flowdesigner.constants.js
@@ -39,4 +39,4 @@ export const FLOWDESIGNER_LINK_REMOVE_DATA = 'FLOWDESIGNER_LINK_REMOVE_DATA';
 export const PORT_SOURCE = 'SOURCE';
 export const PORT_SINK = 'SINK';
 
-export const GRID_SIZE = 62.5;
+export const GRID_SIZE = 40;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
The default grid size is quite big. This makes snap to grid jumpy.

**What is the new behavior?**
Reduce default grid size.