### PR TITLE
fix(zoom): correct svg properties given

### DIFF
--- a/src/components/ZoomHandler.component.js
+++ b/src/components/ZoomHandler.component.js
@@ -3,6 +3,9 @@ import React from 'react';
 import { select, event } from 'd3-selection';
 import { zoom as d3ZoomFactory } from 'd3-zoom';
 
+export function transformToString(transform) {
+	return `translate(${transform.x}, ${transform.y}) scale(${transform.k})`;
+}
 class ZoomHandler extends React.Component {
 	static propTypes = {
 		children: PropTypes.arrayOf(PropTypes.element).isRequired,
@@ -63,7 +66,10 @@ class ZoomHandler extends React.Component {
 	render() {
 		const { transform } = this.state;
 		const childrens = React.Children.map(this.props.children, children =>
-			React.cloneElement(children, { transform }),
+			React.cloneElement(children, {
+				transformData: transform,
+				transform: transformToString(transform),
+			}),
 		);
 		return (
 			<g x="0" y="0" width="100%" height="100%">

--- a/src/components/ZoomHandler.test.js
+++ b/src/components/ZoomHandler.test.js
@@ -1,18 +1,41 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import ZoomHandler from './ZoomHandler.component';
+import ZoomHandler, { transformToString } from './ZoomHandler.component';
 
-describe('<ZoomHandler /> renders correctly', () => {
-	it('<ZoomHandler /> renders correctly', () => {
-		const tree = renderer
-			.create(
-				<ZoomHandler transform={{ x: 0, y: 0, k: 1 }}>
-					<rect />
-					<rect />
-				</ZoomHandler>,
-			)
-			.toJSON();
-		expect(tree).toMatchSnapshot();
+describe('ZoomHandler renders correctly', () => {
+	describe('<ZoomHandler /> renders correctly', () => {
+		it('<ZoomHandler /> renders correctly', () => {
+			// given
+			const transform = { x: 0, y: 0, k: 1 };
+
+			// when
+			const tree = renderer
+				.create(
+					<ZoomHandler transform={transform}>
+						<rect />
+						<rect />
+					</ZoomHandler>,
+				)
+				.toJSON();
+
+			// expect
+			expect(tree).toMatchSnapshot();
+		});
+	});
+	describe('transformToString', () => {
+		// https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform
+		it('generate proper transform string', () => {
+			// given
+			const transform = { x: 1, y: 2, k: -3 };
+
+			// when
+			const stringResult = transformToString(transform);
+
+			// expect
+			expect(stringResult).toEqual(
+				`translate(${transform.x}, ${transform.y}) scale(${transform.k})`,
+			);
+		});
 	});
 });

--- a/src/components/__snapshots__/ZoomHandler.test.js.snap
+++ b/src/components/__snapshots__/ZoomHandler.test.js.snap
@@ -1,4 +1,4 @@
-exports[`<ZoomHandler /> renders correctly <ZoomHandler /> renders correctly 1`] = `
+exports[`ZoomHandler renders correctly <ZoomHandler /> renders correctly <ZoomHandler /> renders correctly 1`] = `
 <g
   height="100%"
   width="100%"
@@ -16,7 +16,8 @@ exports[`<ZoomHandler /> renders correctly <ZoomHandler /> renders correctly 1`]
     x="0"
     y="0" />
   <rect
-    transform={
+    transform="translate(0, 0) scale(1)"
+    transformData={
       Object {
         "k": 1,
         "x": 0,
@@ -24,7 +25,8 @@ exports[`<ZoomHandler /> renders correctly <ZoomHandler /> renders correctly 1`]
       }
     } />
   <rect
-    transform={
+    transform="translate(0, 0) scale(1)"
+    transformData={
       Object {
         "k": 1,
         "x": 0,

--- a/src/components/grid/Grid.component.js
+++ b/src/components/grid/Grid.component.js
@@ -3,10 +3,10 @@ import React from 'react';
 
 import { GRID_SIZE } from '../../constants/flowdesigner.constants';
 
-function Grid({ transform }) {
-	const smallGridSize = 10 * transform.k;
-	const largeGridSize = GRID_SIZE * transform.k;
-	const smallGridOpacity = transform.k < 1 ? transform.k : 1;
+function Grid({ transformData }) {
+	const smallGridSize = 10 * transformData.k;
+	const largeGridSize = GRID_SIZE * transformData.k;
+	const smallGridOpacity = transformData.k < 1 ? transformData.k : 1;
 	return (
 		<g>
 			<defs>
@@ -26,8 +26,8 @@ function Grid({ transform }) {
 					fill="none"
 					stroke="#BFBDBD"
 					strokeWidth="0.5"
-					x={transform.x}
-					y={transform.y}
+					x={transformData.x}
+					y={transformData.y}
 					width={largeGridSize}
 					height={largeGridSize}
 					patternUnits="userSpaceOnUse"
@@ -54,7 +54,7 @@ function Grid({ transform }) {
 }
 
 Grid.propTypes = {
-	transform: PropTypes.shape({
+	transformData: PropTypes.shape({
 		k: PropTypes.number.isRequired,
 		x: PropTypes.number.isRequired,
 		y: PropTypes.number.isRequired,

--- a/src/components/grid/Grid.test.js
+++ b/src/components/grid/Grid.test.js
@@ -5,7 +5,7 @@ import Grid from './Grid.component';
 
 describe('Grid.component', () => {
 	it('should render a grid by default', () => {
-		const tree = renderer.create(<Grid transform={{ k: 1, x: 0, y: 0 }} />);
+		const tree = renderer.create(<Grid transformData={{ k: 1, x: 0, y: 0 }} />);
 		expect(tree).toMatchSnapshot();
 	});
 
@@ -14,7 +14,7 @@ describe('Grid.component', () => {
 			return <g />;
 		}
 		const tree = renderer.create(
-			<Grid transform={{ k: 1, x: 0, y: 0 }} gridComponent={component} />,
+			<Grid transformData={{ k: 1, x: 0, y: 0 }} gridComponent={component} />,
 		);
 		expect(tree).toMatchSnapshot();
 	});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
An object representing a zoom properties was passed to the SVG:transform attribute, this attribute awaiting for a string proped some nasty errors


**What is the new behavior?**
Object is now given trought a custom serialisation so it comply to svg spec
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

the object was usefull for some conveniance calculation.
so it has been kept but is now injected as `transformData` props, shouldn't break anything.


**Other information**: