### PR TITLE
fix(drag): bug when clicking on drag element

### DIFF
--- a/src/components/node/AbstractNode.component.js
+++ b/src/components/node/AbstractNode.component.js
@@ -140,12 +140,14 @@ class AbstractNode extends React.Component {
 	}
 
 	onDragStart() {
+		this.squaredDeltaDrag = 0;
 		if (this.props.onDragStart) {
 			this.props.onDragStart(event);
 		}
 	}
 
 	onDrag() {
+		this.squaredDeltaDrag += (event.dx * event.dx) + (event.dy * event.dy);
 		const position = {
 			x: event.x,
 			y: event.y,
@@ -159,6 +161,15 @@ class AbstractNode extends React.Component {
 	}
 
 	onDragEnd() {
+		// Ok this is pretty specific
+		// for a chrome windows bug
+		// where d3 inhibit onCLick propagation
+		// if there is any delta between down and up of the mouse
+		// here we add a tolerance, so the underlying click doesn't
+		// get smooshed if the user do not initiate drag 
+		if (this.squaredDeltaDrag < 1) {
+			select(window).on('click.drag', null);
+		}
 		const position = this.getEventPosition(event);
 		this.props.moveNodeToEnd(this.props.node.id, position);
 		this.d3Node.data([position]);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
When using chrome + windows, sometimes (hard to reproduce and totaly random)
drag éléménts with theyr behavior tied to d3 drag, just inhibits clicks.


**What is the new behavior?**
add a check for drag tolérance under wich d3-drag should not inhibit the underlying click propagation.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: