### PR TITLE
fix(TFD-3967): remove small-grid

### DIFF
--- a/src/components/grid/Grid.component.js
+++ b/src/components/grid/Grid.component.js
@@ -4,23 +4,10 @@ import React from 'react';
 import { GRID_SIZE } from '../../constants/flowdesigner.constants';
 
 function Grid({ transformData }) {
-	const smallGridSize = 10 * transformData.k;
 	const largeGridSize = GRID_SIZE * transformData.k;
-	const smallGridOpacity = transformData.k < 1 ? transformData.k : 1;
 	return (
 		<g>
 			<defs>
-				<pattern
-					id="smallGrid"
-					fill="none"
-					stroke="#BFBDBD"
-					strokeWidth="0.5"
-					width={smallGridSize}
-					height={smallGridSize}
-					patternUnits="userSpaceOnUse"
-				>
-					<path d={`M ${smallGridSize} 0 L 0 0 0 ${smallGridSize}`} />
-				</pattern>
 				<pattern
 					id="grid"
 					fill="none"
@@ -32,12 +19,7 @@ function Grid({ transformData }) {
 					height={largeGridSize}
 					patternUnits="userSpaceOnUse"
 				>
-					<rect
-						width={largeGridSize}
-						height={largeGridSize}
-						fillOpacity={smallGridOpacity}
-						fill="url(#smallGrid)"
-					/>
+					<rect width={largeGridSize} height={largeGridSize} />
 					<path d={`M ${largeGridSize} 0 L 0 0 0 ${largeGridSize}`} />
 				</pattern>
 			</defs>

--- a/src/components/grid/__snapshots__/Grid.test.js.snap
+++ b/src/components/grid/__snapshots__/Grid.test.js.snap
@@ -3,17 +3,6 @@ exports[`Grid.component should render a grid by default 1`] = `
   <defs>
     <pattern
       fill="none"
-      height={10}
-      id="smallGrid"
-      patternUnits="userSpaceOnUse"
-      stroke="#BFBDBD"
-      strokeWidth="0.5"
-      width={10}>
-      <path
-        d="M 10 0 L 0 0 0 10" />
-    </pattern>
-    <pattern
-      fill="none"
       height={40}
       id="grid"
       patternUnits="userSpaceOnUse"
@@ -23,8 +12,6 @@ exports[`Grid.component should render a grid by default 1`] = `
       x={0}
       y={0}>
       <rect
-        fill="url(#smallGrid)"
-        fillOpacity={1}
         height={40}
         width={40} />
       <path
@@ -50,17 +37,6 @@ exports[`Grid.component should render custom component with transform injected 1
   <defs>
     <pattern
       fill="none"
-      height={10}
-      id="smallGrid"
-      patternUnits="userSpaceOnUse"
-      stroke="#BFBDBD"
-      strokeWidth="0.5"
-      width={10}>
-      <path
-        d="M 10 0 L 0 0 0 10" />
-    </pattern>
-    <pattern
-      fill="none"
       height={40}
       id="grid"
       patternUnits="userSpaceOnUse"
@@ -70,8 +46,6 @@ exports[`Grid.component should render custom component with transform injected 1
       x={0}
       y={0}>
       <rect
-        fill="url(#smallGrid)"
-        fillOpacity={1}
         height={40}
         width={40} />
       <path


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
The smallGrid is not used (hidden via CSS) and that causes issues in Edge. Edge gets a black background instead of white. 

**What is the new behavior?**
Edge shows white background, and smallGrid is removed. 


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: