### PR TITLE
fix(link): moving to pure component for intelligent shallow props check and update

### DIFF
--- a/src/components/link/AbstractLink.component.js
+++ b/src/components/link/AbstractLink.component.js
@@ -23,7 +23,7 @@ function calculatePath(sourcePosition: Position, targetPosition: Position) {
 	return { path, xInterpolate, yInterpolate };
 }
 
-class AbstractLink extends React.Component {
+class AbstractLink extends React.PureComponent {
 	static propTypes = {
 		source: PortType.isRequired,
 		target: PortType.isRequired,
@@ -46,14 +46,6 @@ class AbstractLink extends React.Component {
 	};
 
 	static calculatePath = calculatePath;
-
-	shouldComponentUpdate(nextProps) {
-		return (
-			nextProps.source !== this.props.source ||
-			nextProps.target !== this.props.target ||
-			nextProps.targetHandlePosition !== this.props.targetHandlePosition
-		);
-	}
 
 	renderLinkSourceHandle() {
 		if (this.props.linkSourceHandleComponent) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
Abstract link use a shouldComponentUpdate function to know if rerender or not based on some precise list of props, however this cause issues when adding new props on streams side we have to update this lib


**What is the new behavior?**
use React.PureComponent


**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: