### PR TITLE
fix(portPosition): TFD-3247

### DIFF
--- a/src/reducers/flow.reducer.js
+++ b/src/reducers/flow.reducer.js
@@ -7,6 +7,7 @@ import {
 	FLOWDESIGNER_FLOW_LOAD,
 	FLOWDESIGNER_FLOW_SET_ZOOM,
 	FLOWDESIGNER_PAN_TO,
+	FLOWDESIGNER_NODETYPE_SET,
 } from '../constants/flowdesigner.constants';
 import nodesReducer from './node.reducer';
 import linksReducer from './link.reducer';
@@ -86,6 +87,8 @@ export function reducer(state, action) {
 /**
  * Calculate port position with the methods provided by port parent node
  * calcul is done only if node moved or list of attached port have its size changed
+ * also update position if registered nodetype change
+ * because the node hold the function used to calculate position of their attached port
  * Beware could be slow if the calculus methode provided is slow
  * @params {object} state react-flow-designer state
  * @params {object} oldState react-flow-designer precedentState
@@ -98,7 +101,8 @@ export function calculatePortsPosition(state, action) {
 	if (
 		(/FLOWDESIGNER_NODE_/.exec(action.type) && action.type !== 'FLOWDESIGNER_NODE_REMOVE') ||
 		(/FLOWDESIGNER_PORT_/.exec(action.type) && action.type !== 'FLOWDESIGNER_PORT_REMOVE') ||
-		/FLOWDESIGNER.FLOW_/.exec(action.type)
+		/FLOWDESIGNER.FLOW_/.exec(action.type) ||
+		action.type === FLOWDESIGNER_NODETYPE_SET
 	) {
 		if (action.nodeId) {
 			nodes.push(state.getIn(['nodes', action.nodeId]));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
if pipeline is loaded before Node types are registered, port position is not updated.


**What is the new behavior?**
Add the nodeType action update to the port update action filter so port position are updated if node types are registered after the pipeline is loaded.



**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: