### PR TITLE
feat: add a flag in action and datasetInfo top level property to NodeRecord

### DIFF
--- a/src/actions/__snapshots__/node.actions.test.js.snap
+++ b/src/actions/__snapshots__/node.actions.test.js.snap
@@ -55,6 +55,7 @@ Array [
 exports[`Check that node action creators generate proper action objects and perform checking setNodeData 1`] = `
 Array [
   Object {
+    "bySubmit": undefined,
     "data": Object {
       "type": "test",
     },

--- a/src/actions/node.actions.js
+++ b/src/actions/node.actions.js
@@ -132,10 +132,11 @@ export const removeNodeGraphicalAttribute = (nodeId, graphicalAttributesKey) => 
  * @param {string} nodeId
  * @param {Object} data
  */
-export const setNodeData = (nodeId, data) => ({
+export const setNodeData = (nodeId, data, bySubmit) => ({
 	type: FLOWDESIGNER_NODE_SET_DATA,
 	nodeId,
 	data,
+	bySubmit,
 });
 
 /**

--- a/src/actions/node.actions.js
+++ b/src/actions/node.actions.js
@@ -131,6 +131,7 @@ export const removeNodeGraphicalAttribute = (nodeId, graphicalAttributesKey) => 
  * Give the ability to set data onto a node
  * @param {string} nodeId
  * @param {Object} data
+ * @param {boolean} bySubmit Flag to indicates that the action was triggered by a manual user action
  */
 export const setNodeData = (nodeId, data, bySubmit) => ({
 	type: FLOWDESIGNER_NODE_SET_DATA,

--- a/src/constants/flowdesigner.model.js
+++ b/src/constants/flowdesigner.model.js
@@ -32,6 +32,7 @@ export const NodeData = Record({
 	properties: new Map(),
 	label: '',
 	description: '',
+	datasetInfo: new Map(),
 });
 
 export const LinkGraphicalAttributes = Record({

--- a/src/reducers/__snapshots__/flow.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/flow.reducer.test.js.snap
@@ -13,6 +13,7 @@ Object {
   "nodes": Object {
     "node2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -39,6 +40,7 @@ Object {
     },
     "nodeId": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -124,6 +126,7 @@ Object {
   "nodes": Object {
     "nodeId": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -199,6 +202,7 @@ Object {
   "nodes": Object {
     "node2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -225,6 +229,7 @@ Object {
     },
     "nodeId": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},

--- a/src/reducers/__snapshots__/link.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/link.reducer.test.js.snap
@@ -47,6 +47,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -73,6 +74,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -99,6 +101,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -338,6 +341,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -364,6 +368,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -390,6 +395,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -580,6 +586,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -606,6 +613,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -632,6 +640,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -824,6 +833,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -850,6 +860,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -876,6 +887,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1068,6 +1080,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1094,6 +1107,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1120,6 +1134,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1315,6 +1330,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1341,6 +1357,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1367,6 +1384,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1562,6 +1580,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1588,6 +1607,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1614,6 +1634,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1808,6 +1829,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1834,6 +1856,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -1860,6 +1883,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -2066,6 +2090,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -2092,6 +2117,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -2118,6 +2144,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},

--- a/src/reducers/__snapshots__/node.reducer.test.js.snap
+++ b/src/reducers/__snapshots__/node.reducer.test.js.snap
@@ -11,6 +11,7 @@ Object {
   "nodes": Object {
     "id": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -65,6 +66,7 @@ Object {
   "nodes": Object {
     "id": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -637,6 +639,7 @@ Object {
   "nodes": Object {
     "id1": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -663,6 +666,7 @@ Object {
     },
     "id2": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},
@@ -689,6 +693,7 @@ Object {
     },
     "id3": Object {
       "data": Object {
+        "datasetInfo": Object {},
         "description": "",
         "label": "",
         "properties": Object {},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
- datasetInfo property is not available but it does appear into source/sink forms.
- there is no way to distinguish a NODE_SET_DATA triggered manually from a submit button and the ones triggered programatically within hosting app.

**What is the new behavior?**
- datasetInfo is handled which will make it  undo-redo friendly
- programatic and manual triggers of NODE_SET_DATA can be differentiated


**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: