### PR TITLE
fix: add safari compat

### DIFF
--- a/src/components/grid/Grid.component.js
+++ b/src/components/grid/Grid.component.js
@@ -29,7 +29,7 @@ function Grid({ transformData }) {
 				y="0"
 				width="100%"
 				height="100%"
-				fill="url(#grid)"
+				fill={`url(${window.location.href}#grid)`} // fix for safari url with base attribute
 			/>
 		</g>
 	);

--- a/src/components/grid/__snapshots__/Grid.test.js.snap
+++ b/src/components/grid/__snapshots__/Grid.test.js.snap
@@ -19,7 +19,7 @@ exports[`Grid.component should render a grid by default 1`] = `
     </pattern>
   </defs>
   <rect
-    fill="url(#grid)"
+    fill="url(about:blank#grid)"
     height="100%"
     style={
       Object {
@@ -53,7 +53,7 @@ exports[`Grid.component should render custom component with transform injected 1
     </pattern>
   </defs>
   <rect
-    fill="url(#grid)"
+    fill="url(about:blank#grid)"
     height="100%"
     style={
       Object {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

following this issue https://github.com/airbnb/lottie-web/issues/360
Today safari display the designer as black, it do not understand the url(#grid) effect.

by the way #grid is a little bit weak id.

**What is the new behavior?**

rename the effect
use the window current ref so it work with or without the document has a base.



**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**: