### PR TITLE
chore: nest components through Immutable.Map rather than Immutable.List

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-flow-designer",
   "description": "Flow designer for react and redux",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "lib/index.js",
   "mainSrc": "src/index.js",
   "scripts": {

--- a/src/api/node/node.ts
+++ b/src/api/node/node.ts
@@ -6,7 +6,7 @@ import flow from 'lodash/flow';
 import indexOf from 'lodash/indexOf';
 import isString from 'lodash/isString';
 import upperFirst from 'lodash/upperFirst';
-import { List } from 'immutable';
+import { Map } from 'immutable';
 
 import { throwInDev, throwTypeError } from '../throwInDev';
 import { NodeRecord, NestedNodeRecord } from '../../constants/flowdesigner.model';
@@ -164,8 +164,8 @@ export const setComponentType = curry((nodeType: string, node: NodeRecordType | 
  * @param {NodeRecord} node
  * @returns {NodeRecord}
  */
-export const setComponents = curry((components: List<NodeRecordType>, node: NestedNodeRecordType) => {
-	if (List.isList(components) && isNodeElseThrow(node)) {
+export const setComponents = curry((components: Map<string, NodeRecordType>, node: NestedNodeRecordType) => {
+	if (Map.isMap(components) && isNodeElseThrow(node)) {
 		return node.setIn(componentsSelector, components);
 	}
 	throwInDev(
@@ -338,7 +338,7 @@ export const create = curry(
 				setPosition(position),
 				setSize(size),
 				setComponentType(componentType),
-				setComponents(List()),
+				setComponents(Map()),
 			])(new NestedNodeRecord());
 		}
 

--- a/src/constants/flowdesigner.model.ts
+++ b/src/constants/flowdesigner.model.ts
@@ -101,6 +101,12 @@ export class NodeRecord extends Record({
 export class NestedNodeRecord extends Record({
 	...nodeRecordDefinition,
 	components: List(),
+	getComponents(): Map<string, NestedNodeRecord> {
+		return this.get('components');
+	},
+	setComponents(components: Map<string, NestedNodeRecord>) {
+		return this.set('components', components);
+	},
 	getPosition(): Position {
 		return this.getIn(['graphicalAttributes', 'position']);
 	},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Iterating over an array to find / update / delete a child is boring / boilerplate
The index of the child in the array has no meaning.

**What is the chosen solution to this problem?**
Migrate to Immutable.Map

**Please check if the PR fulfills these requirements**

-   [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)
-   [ ] Related design / discussions / pages, if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
